### PR TITLE
Remove leading and trailing whitespaces in values of converters

### DIFF
--- a/src/main/java/com/github/joschi/jadconfig/converters/BooleanConverter.java
+++ b/src/main/java/com/github/joschi/jadconfig/converters/BooleanConverter.java
@@ -18,6 +18,11 @@ public class BooleanConverter implements Converter<Boolean> {
      */
     @Override
     public Boolean convertFrom(String value) {
+        if (value == null) {
+            throw new ParameterException("Not converting null to Boolean.");
+        }
+
+        value = value.trim();
 
         if ("false".equalsIgnoreCase(value) || "true".equalsIgnoreCase(value)) {
             return Boolean.valueOf(value);

--- a/src/main/java/com/github/joschi/jadconfig/converters/ByteConverter.java
+++ b/src/main/java/com/github/joschi/jadconfig/converters/ByteConverter.java
@@ -18,11 +18,14 @@ public class ByteConverter implements Converter<Byte> {
      */
     @Override
     public Byte convertFrom(String value) {
+        if (value == null) {
+            throw new ParameterException("Not converting null to Byte.");
+        }
 
         Byte result;
 
         try {
-            result = Byte.valueOf(value);
+            result = Byte.valueOf(value.trim());
         } catch (NumberFormatException ex) {
 
             throw new ParameterException("Couldn't convert value \"" + value + "\" to Byte.", ex);

--- a/src/main/java/com/github/joschi/jadconfig/converters/IntegerConverter.java
+++ b/src/main/java/com/github/joschi/jadconfig/converters/IntegerConverter.java
@@ -18,11 +18,14 @@ public class IntegerConverter implements Converter<Integer> {
      */
     @Override
     public Integer convertFrom(String value) {
+        if (value == null) {
+            throw new ParameterException("Not converting null to Integer.");
+        }
 
         Integer result;
 
         try {
-            result = Integer.valueOf(value);
+            result = Integer.valueOf(value.trim());
         } catch (NumberFormatException ex) {
 
             throw new ParameterException("Couldn't convert value \"" + value + "\" to Integer.", ex);

--- a/src/main/java/com/github/joschi/jadconfig/converters/LongConverter.java
+++ b/src/main/java/com/github/joschi/jadconfig/converters/LongConverter.java
@@ -18,11 +18,14 @@ public class LongConverter implements Converter<Long> {
      */
     @Override
     public Long convertFrom(String value) {
+        if (value == null) {
+            throw new ParameterException("Not converting null to Long.");
+        }
 
         Long result;
 
         try {
-            result = Long.valueOf(value);
+            result = Long.valueOf(value.trim());
         } catch (NumberFormatException ex) {
 
             throw new ParameterException("Couldn't convert value \"" + value + "\" to Long.", ex);

--- a/src/main/java/com/github/joschi/jadconfig/converters/ShortConverter.java
+++ b/src/main/java/com/github/joschi/jadconfig/converters/ShortConverter.java
@@ -18,11 +18,14 @@ public class ShortConverter implements Converter<Short> {
      */
     @Override
     public Short convertFrom(String value) {
+        if (value == null) {
+            throw new ParameterException("Not converting null to Short.");
+        }
 
         Short result;
 
         try {
-            result = Short.valueOf(value);
+            result = Short.valueOf(value.trim());
         } catch (NumberFormatException ex) {
 
             throw new ParameterException("Couldn't convert value \"" + value + "\" to Short.", ex);

--- a/src/test/java/com/github/joschi/jadconfig/converters/BooleanConverterTest.java
+++ b/src/test/java/com/github/joschi/jadconfig/converters/BooleanConverterTest.java
@@ -59,4 +59,10 @@ public class BooleanConverterTest {
 
         converter.convertTo(null);
     }
+    
+    @Test
+    public void testConvertFromParameterWithTrailingOrLeadingWhitespaces() {
+        Assert.assertTrue(converter.convertFrom(" true"));
+        Assert.assertFalse(converter.convertFrom("false "));
+    }
 }

--- a/src/test/java/com/github/joschi/jadconfig/converters/ByteConverterTest.java
+++ b/src/test/java/com/github/joschi/jadconfig/converters/ByteConverterTest.java
@@ -69,4 +69,11 @@ public class ByteConverterTest {
 
         converter.convertTo(null);
     }
+    
+    @Test
+    public void testConvertFromParameterWithTrailingOrLeadingWhitespaces() {
+        Assert.assertEquals(Byte.valueOf((byte) 1), converter.convertFrom("1 "));
+        Assert.assertEquals(Byte.valueOf((byte) -1), converter.convertFrom(" -1"));
+    }
+        
 }

--- a/src/test/java/com/github/joschi/jadconfig/converters/DoubleConverterTest.java
+++ b/src/test/java/com/github/joschi/jadconfig/converters/DoubleConverterTest.java
@@ -76,4 +76,10 @@ public class DoubleConverterTest {
 
         converter.convertTo(null);
     }
+    
+    @Test
+    public void testConvertFromParameterWithTrailingOrLeadingWhitespaces() {
+        Assert.assertEquals(Double.valueOf(0.0d), converter.convertFrom(" 0.0"));
+        Assert.assertEquals(Double.valueOf(1.0d), converter.convertFrom("1.0 "));
+    }
 }

--- a/src/test/java/com/github/joschi/jadconfig/converters/FloatConverterTest.java
+++ b/src/test/java/com/github/joschi/jadconfig/converters/FloatConverterTest.java
@@ -77,4 +77,10 @@ public class FloatConverterTest {
 
         converter.convertTo(null);
     }
+    
+    @Test
+    public void testConvertFromParameterWithTrailingOrLeadingWhitespaces() {
+        Assert.assertEquals(Float.valueOf(0.0f), converter.convertFrom(" 0.0"));
+        Assert.assertEquals(Float.valueOf(1.0f), converter.convertFrom("1.0 "));
+    }
 }

--- a/src/test/java/com/github/joschi/jadconfig/converters/IntegerConverterTest.java
+++ b/src/test/java/com/github/joschi/jadconfig/converters/IntegerConverterTest.java
@@ -48,6 +48,12 @@ public class IntegerConverterTest {
         converter.convertFrom(null);
     }
 
+    @Test
+    public void testConvertFromParameterWithTrailingOrLeadingWhitespaces() {
+        Assert.assertEquals(Integer.valueOf(100), converter.convertFrom("100 "));
+        Assert.assertEquals(Integer.valueOf(100), converter.convertFrom(" 100"));
+    }
+
     @Test(expected = ParameterException.class)
     public void testConvertInvalid() {
 

--- a/src/test/java/com/github/joschi/jadconfig/converters/LongConverterTest.java
+++ b/src/test/java/com/github/joschi/jadconfig/converters/LongConverterTest.java
@@ -69,4 +69,10 @@ public class LongConverterTest {
 
         converter.convertTo(null);
     }
+        
+    @Test
+    public void testConvertFromParameterWithTrailingOrLeadingWhitespaces() {
+        Assert.assertEquals(Long.valueOf(0L), converter.convertFrom(" 0"));
+        Assert.assertEquals(Long.valueOf(1L), converter.convertFrom("1 "));
+    }
 }

--- a/src/test/java/com/github/joschi/jadconfig/converters/ShortConverterTest.java
+++ b/src/test/java/com/github/joschi/jadconfig/converters/ShortConverterTest.java
@@ -69,4 +69,10 @@ public class ShortConverterTest {
 
         converter.convertTo(null);
     }
+        
+    @Test
+    public void testConvertFromParameterWithTrailingOrLeadingWhitespaces() {
+        Assert.assertEquals(Short.valueOf((short) 0), converter.convertFrom("0 "));
+        Assert.assertEquals(Short.valueOf((short) 1), converter.convertFrom(" 1"));
+    }
 }


### PR DESCRIPTION
Avoids failing converting of values like "500 "
