### PR TITLE
Fallback property implemented for parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,6 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <version>3.0.2</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <version>3.0.2</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/github/joschi/jadconfig/JadConfig.java
+++ b/src/main/java/com/github/joschi/jadconfig/JadConfig.java
@@ -155,7 +155,6 @@ public class JadConfig {
         }
     }
 
-    @Nullable
     private String lookupFallbackParameter(Parameter parameter) {
         final Optional<String> fallbackValue = Optional.ofNullable(parameter.fallbackPropertyName())
                 .filter(fallbackName -> !fallbackName.trim().isEmpty())

--- a/src/main/java/com/github/joschi/jadconfig/JadConfig.java
+++ b/src/main/java/com/github/joschi/jadconfig/JadConfig.java
@@ -2,7 +2,7 @@ package com.github.joschi.jadconfig;
 
 import com.github.joschi.jadconfig.converters.NoConverter;
 import com.github.joschi.jadconfig.converters.StringConverter;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/com/github/joschi/jadconfig/Parameter.java
+++ b/src/main/java/com/github/joschi/jadconfig/Parameter.java
@@ -58,7 +58,9 @@ public @interface Parameter {
 
     /**
      * Optional fallback name of the configuration option in the {@link Repository}
-     * Used only when the original name in {@link #value()} doesn't deliver any results in the repository
+     * Used only when the original name in {@link #value()} doesn't deliver any results in the repository.
+     * If you have a hardcoded value in the field, it will be used only as a last resort. The order is {@link #value()},
+     * then {@link #fallbackPropertyName()} and if there are no values, only then the field value will be used (=stays untouched)
      */
     String fallbackPropertyName() default "";
 }

--- a/src/main/java/com/github/joschi/jadconfig/Parameter.java
+++ b/src/main/java/com/github/joschi/jadconfig/Parameter.java
@@ -55,4 +55,10 @@ public @interface Parameter {
      * Specific {@link Validator}s to use for this parameter.
      */
     Class<? extends Validator<?>>[] validators() default {NoValidator.class};
+
+    /**
+     * Optional fallback name of the configuration option in the {@link Repository}
+     * Used only when the original name in {@link #value()} doesn't deliver any results in the repository
+     */
+    String fallbackPropertyName() default "";
 }

--- a/src/test/java/com/github/joschi/jadconfig/JadConfigTest.java
+++ b/src/test/java/com/github/joschi/jadconfig/JadConfigTest.java
@@ -99,6 +99,8 @@ public class JadConfigTest {
         Assert.assertEquals("Test", configurationBean.getMyFallbackString());
         Assert.assertEquals("prim", configurationBean.getMyPrimSecString());
         Assert.assertNull(configurationBean.getMyNonexistentString());
+        Assert.assertEquals("sec", configurationBean.getMyHardcodedDefaultString());
+
     }
 
     @Test

--- a/src/test/java/com/github/joschi/jadconfig/JadConfigTest.java
+++ b/src/test/java/com/github/joschi/jadconfig/JadConfigTest.java
@@ -91,6 +91,17 @@ public class JadConfigTest {
     }
 
     @Test
+    public void testFallbackLogic() throws ValidationException, RepositoryException {
+        SimpleConfigurationBean configurationBean = new SimpleConfigurationBean();
+        jadConfig = new JadConfig(repository, configurationBean);
+
+        jadConfig.process();
+        Assert.assertEquals("Test", configurationBean.getMyFallbackString());
+        Assert.assertEquals("prim", configurationBean.getMyPrimSecString());
+        Assert.assertNull(configurationBean.getMyNonexistentString());
+    }
+
+    @Test
     public void testProcessWithMultipleRepositories() throws RepositoryException, ValidationException {
 
         final SimpleConfigurationBean configurationBean = new SimpleConfigurationBean();

--- a/src/test/java/com/github/joschi/jadconfig/testbeans/SimpleConfigurationBean.java
+++ b/src/test/java/com/github/joschi/jadconfig/testbeans/SimpleConfigurationBean.java
@@ -46,6 +46,15 @@ public class SimpleConfigurationBean {
     @Parameter("test.path")
     private Path path;
 
+    @Parameter(value = "test.Nonexistent", fallbackPropertyName = "test.string")
+    private String myFallbackString;
+
+    @Parameter(value = "test.fallback.primary", fallbackPropertyName = "test.fallback.secondary")
+    private String myPrimSecString;
+
+    @Parameter(value = "test.Nonexistent", fallbackPropertyName = "test.AlsoNonexistent")
+    private String myNonexistentString;
+
     public String getMyString() {
         return myString;
     }
@@ -92,5 +101,17 @@ public class SimpleConfigurationBean {
 
     public Path getPath() {
         return path;
+    }
+
+    public String getMyFallbackString() {
+        return myFallbackString;
+    }
+
+    public String getMyPrimSecString() {
+        return myPrimSecString;
+    }
+
+    public String getMyNonexistentString() {
+        return myNonexistentString;
     }
 }

--- a/src/test/java/com/github/joschi/jadconfig/testbeans/SimpleConfigurationBean.java
+++ b/src/test/java/com/github/joschi/jadconfig/testbeans/SimpleConfigurationBean.java
@@ -55,6 +55,9 @@ public class SimpleConfigurationBean {
     @Parameter(value = "test.Nonexistent", fallbackPropertyName = "test.AlsoNonexistent")
     private String myNonexistentString;
 
+    @Parameter(value = "test.Nonexistent", fallbackPropertyName = "test.fallback.secondary")
+    private String myHardcodedDefaultString = "foobar";
+
     public String getMyString() {
         return myString;
     }
@@ -113,5 +116,9 @@ public class SimpleConfigurationBean {
 
     public String getMyNonexistentString() {
         return myNonexistentString;
+    }
+
+    public String getMyHardcodedDefaultString() {
+        return myHardcodedDefaultString;
     }
 }

--- a/src/test/resources/testConfiguration.properties
+++ b/src/test/resources/testConfiguration.properties
@@ -14,3 +14,5 @@ test.list=one,two,three,four,five
 test.uri=http://example.com/
 test.file=testConfiguration.properties
 test.path=testConfiguration.properties
+test.fallback.primary=prim
+test.fallback.secondary=sec


### PR DESCRIPTION
Add support for fallback property name:

```
 @Parameter(value = "test.fallback.primary", fallbackPropertyName = "test.fallback.secondary")
    private String myPrimSecString;
```
If the key `test.fallback.primary` can't be found in any repository, the library will try to resolve value of `test.fallback.secondary`. If this succeeds, the value will be provided, together with a WARN message:

```
[main] WARN com.github.joschi.jadconfig.JadConfig - Primary parameter test.fallback.primary not found, using the fallback value of test.fallback.secondary. Please correct your configuration if possible.
```


## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

