### PR TITLE
Validate default values

### DIFF
--- a/src/main/java/com/github/joschi/jadconfig/JadConfig.java
+++ b/src/main/java/com/github/joschi/jadconfig/JadConfig.java
@@ -186,12 +186,9 @@ public class JadConfig {
                 } catch (ParameterException e) {
                     throw new ParameterException("Couldn't convert value for parameter \"" + parameterName + "\"", e);
                 }
-
-                LOG.debug("Validating parameter {}", parameterName);
-                final List<Class<? extends Validator<?>>> validators =
-                        new ArrayList<>(Collections.<Class<? extends Validator<?>>>singleton(parameter.validator()));
-                validators.addAll(Arrays.asList(parameter.validators()));
-                validateParameter(validators, parameterName, fieldValue);
+                validateFieldValue(parameterName, parameter, fieldValue);
+            } else if (fieldValue != null) {
+                validateFieldValue(parameterName, parameter, fieldValue);
             }
 
             LOG.debug("Setting parameter {} to {}", parameterName, fieldValue);
@@ -202,6 +199,14 @@ public class JadConfig {
                 throw new ParameterException("Couldn't set field " + field.getName(), e);
             }
         }
+    }
+
+    private void validateFieldValue(String parameterName, Parameter parameter, Object fieldValue) throws ValidationException {
+        LOG.debug("Validating parameter {}", parameterName);
+        final List<Class<? extends Validator<?>>> validators =
+                new ArrayList<>(Collections.<Class<? extends Validator<?>>>singleton(parameter.validator()));
+        validators.addAll(Arrays.asList(parameter.validators()));
+        validateParameter(validators, parameterName, fieldValue);
     }
 
     private String lookupFallbackParameter(Parameter parameter) {

--- a/src/test/java/com/github/joschi/jadconfig/JadConfigTest.java
+++ b/src/test/java/com/github/joschi/jadconfig/JadConfigTest.java
@@ -8,6 +8,7 @@ import com.github.joschi.jadconfig.testbeans.EmptyBean;
 import com.github.joschi.jadconfig.testbeans.FoobarConfigurationBean;
 import com.github.joschi.jadconfig.testbeans.InheritedBeanSubClass;
 import com.github.joschi.jadconfig.testbeans.InheritedBeanSubSubClass;
+import com.github.joschi.jadconfig.testbeans.InvalidDefaultValueValidatorBean;
 import com.github.joschi.jadconfig.testbeans.Multi1ConfigurationBean;
 import com.github.joschi.jadconfig.testbeans.Multi2ConfigurationBean;
 import com.github.joschi.jadconfig.testbeans.NonExistingParameterBean;
@@ -502,6 +503,16 @@ public class JadConfigTest {
         Assert.assertEquals(123456, configurationBean.getMyInt());
         Assert.assertEquals(1234567890123L, configurationBean.getMyLong());
     }
+
+    @Test
+    public void testProcessValidatedBeanInvalidDefaultValue() {
+        InvalidDefaultValueValidatorBean configurationBean = new InvalidDefaultValueValidatorBean();
+        jadConfig = new JadConfig(repository, configurationBean);
+
+        // the default value is -1, validator expects only positive longs => validation exception
+        Assert.assertThrows(ValidationException.class, () -> jadConfig.process());
+    }
+
 
     @Test
     public void testProcessNullPropertiesDoNotOverwriteDefaultValues() throws RepositoryException, ValidationException {

--- a/src/test/java/com/github/joschi/jadconfig/testbeans/InvalidDefaultValueValidatorBean.java
+++ b/src/test/java/com/github/joschi/jadconfig/testbeans/InvalidDefaultValueValidatorBean.java
@@ -1,0 +1,14 @@
+package com.github.joschi.jadconfig.testbeans;
+
+import com.github.joschi.jadconfig.Parameter;
+import com.github.joschi.jadconfig.validators.PositiveLongValidator;
+
+public class InvalidDefaultValueValidatorBean {
+
+    @Parameter(value = "test.positive.long", validator = PositiveLongValidator.class)
+    private long myPositiveLong = -1;
+
+    public long getMyPositiveLong() {
+        return myPositiveLong;
+    }
+}


### PR DESCRIPTION
So far we have ignored validation of default values. These are given by us, as a field value of the configuration property. This would be a valid configuration that causes no errors during init:

```
@Parameter(value = "test.positive.long", validator = PositiveLongValidator.class)
private long myPositiveLong = -1;
```

But it's obviously wrong and will cause, sooner or later, problems elsewhere. That's why I believe is correct to validate default values as well. 

In the best case, we would validate these during compile time, not during run time. But some of the properties are paths and config related to the running system, so we are unable to determine if the value is correct or not during compilation. Runtime check is the next best thing to avoid problems later in the execution.


## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

