### PR TITLE
Aggregated parameter implementation

### DIFF
--- a/src/main/java/com/github/joschi/jadconfig/AggregatedParameter.java
+++ b/src/main/java/com/github/joschi/jadconfig/AggregatedParameter.java
@@ -17,5 +17,10 @@ public @interface AggregatedParameter {
      * as defined. So if you want to match opensearch.path.repo and opensearch.node.roles, your prefix should be
      * {@code opensearch.}
      */
-    String prefix();
+    String[] prefix();
+
+    /**
+     * Should the prefix be removed from collected property names?
+     */
+    boolean stripPrefix() default false;
 }

--- a/src/main/java/com/github/joschi/jadconfig/AggregatedParameter.java
+++ b/src/main/java/com/github/joschi/jadconfig/AggregatedParameter.java
@@ -1,0 +1,21 @@
+package com.github.joschi.jadconfig;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation is intended to collect all configuration properties starting with the same prefix.
+ * Think opensearch.path.repo and opensearch.node.roles values aggregated as a {@code Map<String,String>}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface AggregatedParameter {
+    /**
+     * The prefix that will be used to match configuration properties. There is no preprocessing and it will be used
+     * as defined. So if you want to match opensearch.path.repo and opensearch.node.roles, your prefix should be
+     * {@code opensearch.}
+     */
+    String prefix();
+}

--- a/src/main/java/com/github/joschi/jadconfig/Repository.java
+++ b/src/main/java/com/github/joschi/jadconfig/Repository.java
@@ -1,5 +1,7 @@
 package com.github.joschi.jadconfig;
 
+import java.util.Collection;
+
 /**
  * Interface for configuration repositories
  * <p>A configuration repository can be any data source containing configuration data,
@@ -24,6 +26,8 @@ public interface Repository {
      * @return The value of the provided {@literal name} as {@link String}
      */
     String read(String name);
+
+    Collection<String> readNames(String prefix);
 
     /**
      * Closes the underlying data source when it isn't require any more.

--- a/src/main/java/com/github/joschi/jadconfig/Repository.java
+++ b/src/main/java/com/github/joschi/jadconfig/Repository.java
@@ -27,6 +27,9 @@ public interface Repository {
      */
     String read(String name);
 
+    /**
+     * Reads all available property names beginning with {@code prefix}.
+     */
     Collection<String> readNames(String prefix);
 
     /**

--- a/src/main/java/com/github/joschi/jadconfig/repositories/EnvironmentRepository.java
+++ b/src/main/java/com/github/joschi/jadconfig/repositories/EnvironmentRepository.java
@@ -15,13 +15,13 @@ import java.util.stream.Collectors;
  * A prefix for all key lookups can be defined with {@link #EnvironmentRepository(String)}.
  * The default prefix is empty.
  *
- * @see System#getenv()
- * @see System#getenv(String)
+ * @see java.lang.System#getenv()
+ * @see java.lang.System#getenv(String)
  */
 public class EnvironmentRepository implements Repository {
-
     private final String prefix;
     private final boolean upperCase;
+    private final JavaSystem system;
 
     /**
      * Creates a new instance of {@link EnvironmentRepository} with the default settings,
@@ -56,8 +56,13 @@ public class EnvironmentRepository implements Repository {
      * @param upperCase Whether keys should be looked up in upper case.
      */
     public EnvironmentRepository(final String prefix, boolean upperCase) {
+        this(prefix, upperCase, JavaLangSystem.INSTANCE);
+    }
+
+    public EnvironmentRepository(String prefix, boolean upperCase, JavaSystem system) {
         this.prefix = prefix;
         this.upperCase = upperCase;
+        this.system = system;
     }
 
     @Override
@@ -67,37 +72,30 @@ public class EnvironmentRepository implements Repository {
 
     @Override
     public String read(final String name) {
-        final String envName;
-
-        if (upperCase) {
-            envName = (prefix + name).toUpperCase();
-        } else {
-            envName = prefix + name;
-        }
-
-        return System.getenv(envName);
+        final String envName = constructPropertyName(name);
+        return system.getenv(envName);
     }
 
     @Override
     public Collection<String> readNames(String namePrefix) {
+        final String envName = constructPropertyName(namePrefix);
+        return system.getenv().keySet().stream().filter(e -> e.startsWith(envName)).collect(Collectors.toSet());
+    }
 
-        final String envName;
-
+    private String constructPropertyName(String name) {
         if (upperCase) {
-            envName = (prefix + namePrefix).toUpperCase();
+            return  (prefix + name).toUpperCase();
         } else {
-            envName = prefix + namePrefix;
+            return prefix + name;
         }
-
-        return System.getenv().keySet().stream().filter(e -> e.startsWith(envName)).collect(Collectors.toSet());
     }
 
     @Override
-    public void close() throws RepositoryException {
+    public void close() {
         // NOP
     }
 
     public int size() {
-        return System.getenv().size();
+        return system.getenv().size();
     }
 }

--- a/src/main/java/com/github/joschi/jadconfig/repositories/EnvironmentRepository.java
+++ b/src/main/java/com/github/joschi/jadconfig/repositories/EnvironmentRepository.java
@@ -79,7 +79,11 @@ public class EnvironmentRepository implements Repository {
     @Override
     public Collection<String> readNames(String namePrefix) {
         final String envName = constructPropertyName(namePrefix);
-        return system.getenv().keySet().stream().filter(e -> e.startsWith(envName)).collect(Collectors.toSet());
+        return system.getenv().keySet()
+                .stream()
+                .filter(e -> e.startsWith(envName))
+                .map(propertyName -> propertyName.replaceFirst(prefix, ""))
+                .collect(Collectors.toSet());
     }
 
     private String constructPropertyName(String name) {

--- a/src/main/java/com/github/joschi/jadconfig/repositories/EnvironmentRepository.java
+++ b/src/main/java/com/github/joschi/jadconfig/repositories/EnvironmentRepository.java
@@ -3,6 +3,9 @@ package com.github.joschi.jadconfig.repositories;
 import com.github.joschi.jadconfig.Repository;
 import com.github.joschi.jadconfig.RepositoryException;
 
+import java.util.Collection;
+import java.util.stream.Collectors;
+
 /**
  * {@link Repository} class providing access to environment variables.
  * <p/>
@@ -73,6 +76,20 @@ public class EnvironmentRepository implements Repository {
         }
 
         return System.getenv(envName);
+    }
+
+    @Override
+    public Collection<String> readNames(String namePrefix) {
+
+        final String envName;
+
+        if (upperCase) {
+            envName = (prefix + namePrefix).toUpperCase();
+        } else {
+            envName = prefix + namePrefix;
+        }
+
+        return System.getenv().keySet().stream().filter(e -> e.startsWith(envName)).collect(Collectors.toSet());
     }
 
     @Override

--- a/src/main/java/com/github/joschi/jadconfig/repositories/InMemoryRepository.java
+++ b/src/main/java/com/github/joschi/jadconfig/repositories/InMemoryRepository.java
@@ -3,8 +3,10 @@ package com.github.joschi.jadconfig.repositories;
 import com.github.joschi.jadconfig.Repository;
 import com.github.joschi.jadconfig.RepositoryException;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * {@link Repository} class providing access to a simple configuration repository backed by {@link HashMap}
@@ -40,6 +42,11 @@ public class InMemoryRepository implements Repository {
         }
 
         return properties.get(name);
+    }
+
+    @Override
+    public Collection<String> readNames(String prefix) {
+        return properties.keySet().stream().filter(key -> key.startsWith(prefix)).collect(Collectors.toSet());
     }
 
     @Override

--- a/src/main/java/com/github/joschi/jadconfig/repositories/InMemoryRepository.java
+++ b/src/main/java/com/github/joschi/jadconfig/repositories/InMemoryRepository.java
@@ -5,6 +5,7 @@ import com.github.joschi.jadconfig.RepositoryException;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -15,9 +16,10 @@ import java.util.stream.Collectors;
  */
 public class InMemoryRepository implements Repository {
 
-    private Map<String, String> properties = null;
+    private final Map<String, String> properties;
 
     public InMemoryRepository() {
+        this(new LinkedHashMap<>());
     }
 
     public InMemoryRepository(Map<String, String> properties) {
@@ -26,21 +28,10 @@ public class InMemoryRepository implements Repository {
 
     @Override
     public void open() throws RepositoryException {
-
-        if (properties == null) {
-
-            properties = new HashMap<String, String>();
-        }
     }
 
     @Override
     public String read(String name) {
-
-        if (properties == null) {
-
-            throw new IllegalStateException("Repository has already been closed or has never been opened");
-        }
-
         return properties.get(name);
     }
 
@@ -50,23 +41,6 @@ public class InMemoryRepository implements Repository {
     }
 
     @Override
-    public void close() throws RepositoryException {
-
-        if (properties == null) {
-
-            throw new IllegalStateException("Repository has already been closed or has never been opened");
-        }
-
-        properties = null;
-    }
-
-    public int size() {
-
-        if (properties == null) {
-
-            throw new IllegalStateException("Call open before attempting any other operation");
-        }
-
-        return properties.size();
+    public void close() {
     }
 }

--- a/src/main/java/com/github/joschi/jadconfig/repositories/JavaLangSystem.java
+++ b/src/main/java/com/github/joschi/jadconfig/repositories/JavaLangSystem.java
@@ -1,0 +1,32 @@
+package com.github.joschi.jadconfig.repositories;
+
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Delegates all env and properties calls to the underlying {@link java.lang.System}
+ */
+public class JavaLangSystem implements JavaSystem {
+
+    public static final JavaSystem INSTANCE = new JavaLangSystem();
+
+    @Override
+    public Map<String, String> getenv() {
+        return java.lang.System.getenv();
+    }
+
+    @Override
+    public String getenv(String name) {
+        return java.lang.System.getenv(name);
+    }
+
+    @Override
+    public Properties getProperties() {
+        return java.lang.System.getProperties();
+    }
+
+    @Override
+    public String getProperty(String key) {
+        return java.lang.System.getProperty(key);
+    }
+}

--- a/src/main/java/com/github/joschi/jadconfig/repositories/JavaSystem.java
+++ b/src/main/java/com/github/joschi/jadconfig/repositories/JavaSystem.java
@@ -1,0 +1,14 @@
+package com.github.joschi.jadconfig.repositories;
+
+import java.util.Properties;
+
+/**
+ * Abstraction to separate {@link java.lang.System} env and properties, to avoid static usage of the System class
+ * and reliable unit testing od repositories, independent of actual underlying system.
+ */
+public interface JavaSystem {
+    java.util.Map<String,String> getenv();
+    String getenv(String name);
+    Properties getProperties();
+    String getProperty(String key);
+}

--- a/src/main/java/com/github/joschi/jadconfig/repositories/PropertiesRepository.java
+++ b/src/main/java/com/github/joschi/jadconfig/repositories/PropertiesRepository.java
@@ -7,7 +7,9 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
+import java.util.Collection;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 /**
  * {@link Repository} class providing access to a configuration repository backed by {@link Properties} files
@@ -98,6 +100,11 @@ public class PropertiesRepository implements Repository {
     public String read(String name) {
 
         return PROPERTIES.getProperty(name);
+    }
+
+    @Override
+    public Collection<String> readNames(String prefix) {
+        return PROPERTIES.stringPropertyNames().stream().filter(name -> name.startsWith(prefix)).collect(Collectors.toSet());
     }
 
     /**

--- a/src/main/java/com/github/joschi/jadconfig/repositories/SystemPropertiesRepository.java
+++ b/src/main/java/com/github/joschi/jadconfig/repositories/SystemPropertiesRepository.java
@@ -56,8 +56,11 @@ public class SystemPropertiesRepository implements Repository {
     }
 
     @Override
-    public Collection<String> readNames(String prefix) {
-        return system.getProperties().stringPropertyNames().stream().filter(key -> key.startsWith(prefix)).collect(Collectors.toSet());
+    public Collection<String> readNames(String namePrefix) {
+        return system.getProperties().stringPropertyNames().stream()
+                .filter(key -> key.startsWith(prefix + namePrefix))
+                .map(propertyName -> propertyName.replaceFirst(prefix, ""))
+                .collect(Collectors.toSet());
     }
 
     @Override

--- a/src/main/java/com/github/joschi/jadconfig/repositories/SystemPropertiesRepository.java
+++ b/src/main/java/com/github/joschi/jadconfig/repositories/SystemPropertiesRepository.java
@@ -3,6 +3,9 @@ package com.github.joschi.jadconfig.repositories;
 import com.github.joschi.jadconfig.Repository;
 import com.github.joschi.jadconfig.RepositoryException;
 
+import java.util.Collection;
+import java.util.stream.Collectors;
+
 /**
  * {@link Repository} class providing access to System properties.
  * <p/>
@@ -44,6 +47,11 @@ public class SystemPropertiesRepository implements Repository {
     public String read(String name) {
 
         return System.getProperty(prefix + name);
+    }
+
+    @Override
+    public Collection<String> readNames(String prefix) {
+        return System.getProperties().stringPropertyNames().stream().filter(key -> key.startsWith(prefix)).collect(Collectors.toSet());
     }
 
     @Override

--- a/src/main/java/com/github/joschi/jadconfig/repositories/SystemPropertiesRepository.java
+++ b/src/main/java/com/github/joschi/jadconfig/repositories/SystemPropertiesRepository.java
@@ -13,12 +13,13 @@ import java.util.stream.Collectors;
  * The default prefix is empty.
  *
  * @author jschalanda
- * @see System#getProperties()
- * @see System#getProperty(String)
+ * @see java.lang.System#getProperties()
+ * @see java.lang.System#getProperty(String)
  */
 public class SystemPropertiesRepository implements Repository {
 
     private final String prefix;
+    private final JavaSystem system;
 
     /**
      * Creates a new instance of {@link SystemPropertiesRepository} with the default settings,
@@ -28,40 +29,40 @@ public class SystemPropertiesRepository implements Repository {
         this("");
     }
 
+
+    public SystemPropertiesRepository(String prefix) {
+        this(prefix, JavaLangSystem.INSTANCE);
+    }
+
+
     /**
      * Creates a new instance of {@link SystemPropertiesRepository} with the given prefix.
      *
      * @param prefix The prefix used for key lookups, e. g. {@code "custom."}.
      */
-    public SystemPropertiesRepository(final String prefix) {
+    public SystemPropertiesRepository(final String prefix, JavaSystem system) {
         this.prefix = prefix;
+        this.system = system;
     }
 
     @Override
     public void open() throws RepositoryException {
-
         // NOP
     }
 
     @Override
     public String read(String name) {
-
-        return System.getProperty(prefix + name);
+        return system.getProperty(prefix + name);
     }
 
     @Override
     public Collection<String> readNames(String prefix) {
-        return System.getProperties().stringPropertyNames().stream().filter(key -> key.startsWith(prefix)).collect(Collectors.toSet());
+        return system.getProperties().stringPropertyNames().stream().filter(key -> key.startsWith(prefix)).collect(Collectors.toSet());
     }
 
     @Override
-    public void close() throws RepositoryException {
-
+    public void close() {
         // NOP
     }
 
-    public int size() {
-
-        return System.getProperties().size();
-    }
 }

--- a/src/test/java/com/github/joschi/jadconfig/AggregatedPropertiesTest.java
+++ b/src/test/java/com/github/joschi/jadconfig/AggregatedPropertiesTest.java
@@ -18,10 +18,11 @@ public class AggregatedPropertiesTest {
         jadConfig.process();
 
         Assert.assertNotNull(configurationBean.getOpensearchProperties());
-        Assert.assertEquals(3, configurationBean.getOpensearchProperties().size());
+        Assert.assertEquals(4, configurationBean.getOpensearchProperties().size());
 
-        Assert.assertEquals("search,cluster_manager", configurationBean.getOpensearchProperties().get("opensearch.node.roles"));
-        Assert.assertEquals("10gb", configurationBean.getOpensearchProperties().get("opensearch.node.search.cache.size"));
-        Assert.assertEquals("/tmp", configurationBean.getOpensearchProperties().get("opensearch.path.repo"));
+        Assert.assertEquals("search,cluster_manager", configurationBean.getOpensearchProperties().get("node.roles"));
+        Assert.assertEquals("10gb", configurationBean.getOpensearchProperties().get("node.search.cache.size"));
+        Assert.assertEquals("/tmp", configurationBean.getOpensearchProperties().get("path.repo"));
+        Assert.assertEquals("debug", configurationBean.getOpensearchProperties().get("logger.reindex.level"));
     }
 }

--- a/src/test/java/com/github/joschi/jadconfig/AggregatedPropertiesTest.java
+++ b/src/test/java/com/github/joschi/jadconfig/AggregatedPropertiesTest.java
@@ -1,0 +1,27 @@
+package com.github.joschi.jadconfig;
+
+import com.github.joschi.jadconfig.repositories.PropertiesRepository;
+import com.github.joschi.jadconfig.testbeans.SimpleConfigurationBean;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AggregatedPropertiesTest {
+
+    private static final String PROPERTIES_FILE = PropertiesRepository.class.getResource("/testConfiguration.properties").getFile();
+
+    @Test
+    public void testPrefixProperties() throws ValidationException, RepositoryException {
+        final PropertiesRepository repository = new PropertiesRepository(PROPERTIES_FILE);
+
+        final SimpleConfigurationBean configurationBean = new SimpleConfigurationBean();
+        final JadConfig jadConfig = new JadConfig(repository, configurationBean);
+        jadConfig.process();
+
+        Assert.assertNotNull(configurationBean.getOpensearchProperties());
+        Assert.assertEquals(3, configurationBean.getOpensearchProperties().size());
+
+        Assert.assertEquals("search,cluster_manager", configurationBean.getOpensearchProperties().get("opensearch.node.roles"));
+        Assert.assertEquals("10gb", configurationBean.getOpensearchProperties().get("opensearch.node.search.cache.size"));
+        Assert.assertEquals("/tmp", configurationBean.getOpensearchProperties().get("opensearch.path.repo"));
+    }
+}

--- a/src/test/java/com/github/joschi/jadconfig/repositories/EnvironmentRepositoryTest.java
+++ b/src/test/java/com/github/joschi/jadconfig/repositories/EnvironmentRepositoryTest.java
@@ -52,14 +52,17 @@ public class EnvironmentRepositoryTest {
     }
 
     @Test
-    public void testreadNames() {
+    public void testReadNames() {
         final TestSystem env = new TestSystem();
-        env.putEnv("OPENSEARCH_NODE_NAME", "my-node");
-        env.putEnv("OPENSEARCH_NODE_ROLE", "search");
-        final Repository testRepository = new EnvironmentRepository("", true, env);
+        env.putEnv("GRAYLOG_DATANODE_OPENSEARCH_NODE_NAME", "my-node");
+        env.putEnv("GRAYLOG_DATANODE_OPENSEARCH_NODE_ROLE", "search");
+        final Repository testRepository = new EnvironmentRepository("GRAYLOG_DATANODE_", true, env);
         final Collection<String> names = testRepository.readNames("OPENSEARCH_");
         Assert.assertEquals(2, names.size());
         Assert.assertTrue(names.contains("OPENSEARCH_NODE_NAME"));
         Assert.assertTrue(names.contains("OPENSEARCH_NODE_ROLE"));
+
+        Assert.assertEquals("my-node", testRepository.read("OPENSEARCH_NODE_NAME"));
+        Assert.assertEquals("search", testRepository.read("OPENSEARCH_NODE_ROLE"));
     }
 }

--- a/src/test/java/com/github/joschi/jadconfig/repositories/EnvironmentRepositoryTest.java
+++ b/src/test/java/com/github/joschi/jadconfig/repositories/EnvironmentRepositoryTest.java
@@ -1,9 +1,11 @@
 package com.github.joschi.jadconfig.repositories;
 
+import com.github.joschi.jadconfig.Repository;
 import com.github.joschi.jadconfig.RepositoryException;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Collection;
 
 /**
  * Unit tests for {@link EnvironmentRepository}
@@ -12,59 +14,52 @@ import org.junit.Test;
  */
 public class EnvironmentRepositoryTest {
 
-    private EnvironmentRepository repository;
-
-    @Before
-    public void setUp() {
-
-        repository = new EnvironmentRepository();
-    }
-
-    @Test
-    public void testOpen() throws RepositoryException {
-
-        repository.open();
-    }
-
-    @Test
-    public void testClose() throws RepositoryException {
-
-        repository.close();
-    }
-
     @Test
     public void testRead() throws RepositoryException {
-
+        final TestSystem testEnv = new TestSystem();
+        testEnv.putEnv("JAVA_HOME", "/usr/share/java");
+        final Repository repository = new EnvironmentRepository("", true, testEnv);
         Assert.assertNull(repository.read("This environment variable should not exist"));
-
-        Assert.assertEquals(System.getenv("JAVA_HOME"), repository.read("JAVA_HOME"));
+        Assert.assertEquals("/usr/share/java", repository.read("JAVA_HOME"));
     }
 
     @Test
     public void testUpperCaseEnabledRead() throws RepositoryException {
-        final EnvironmentRepository testRepository = new EnvironmentRepository(true);
-
-        Assert.assertEquals(System.getenv("JAVA_HOME"), testRepository.read("jAvA_homE"));
+        final TestSystem testEnv = new TestSystem();
+        testEnv.putEnv("JAVA_HOME", "/usr/share/java");
+        final Repository repository = new EnvironmentRepository("", true, testEnv);
+        Assert.assertEquals("/usr/share/java", repository.read("jAvA_homE"));
     }
 
     @Test
     public void testUpperCaseDisabledRead() throws RepositoryException {
-        final EnvironmentRepository testRepository = new EnvironmentRepository(false);
+        final TestSystem testEnv = new TestSystem();
+        testEnv.putEnv("JAVA_HOME", "/usr/share/java");
+        final Repository repository = new EnvironmentRepository("", false, testEnv);
 
-        Assert.assertNull(testRepository.read("jAvA_homE"));
-        Assert.assertEquals(System.getenv("JAVA_HOME"), testRepository.read("JAVA_HOME"));
+        Assert.assertNull(repository.read("jAvA_homE"));
+        Assert.assertEquals("/usr/share/java", repository.read("JAVA_HOME"));
     }
 
     @Test
     public void testPrefixedRead() throws RepositoryException {
-        final EnvironmentRepository testRepository = new EnvironmentRepository("JAVA_");
 
-        Assert.assertEquals(System.getenv("JAVA_HOME"), testRepository.read("HOME"));
+        final TestSystem testEnv = new TestSystem();
+        testEnv.putEnv("JAVA_HOME", "/usr/share/java");
+        final Repository repository = new EnvironmentRepository("JAVA_", true, testEnv);
+
+        Assert.assertEquals("/usr/share/java", repository.read("HOME"));
     }
 
     @Test
-    public void testSize() throws RepositoryException {
-
-        Assert.assertEquals(System.getenv().size(), repository.size());
+    public void testreadNames() {
+        final TestSystem env = new TestSystem();
+        env.putEnv("OPENSEARCH_NODE_NAME", "my-node");
+        env.putEnv("OPENSEARCH_NODE_ROLE", "search");
+        final Repository testRepository = new EnvironmentRepository("", true, env);
+        final Collection<String> names = testRepository.readNames("OPENSEARCH_");
+        Assert.assertEquals(2, names.size());
+        Assert.assertTrue(names.contains("OPENSEARCH_NODE_NAME"));
+        Assert.assertTrue(names.contains("OPENSEARCH_NODE_ROLE"));
     }
 }

--- a/src/test/java/com/github/joschi/jadconfig/repositories/InMemoryRepositoryTest.java
+++ b/src/test/java/com/github/joschi/jadconfig/repositories/InMemoryRepositoryTest.java
@@ -1,94 +1,29 @@
 package com.github.joschi.jadconfig.repositories;
 
+import com.github.joschi.jadconfig.Repository;
 import com.github.joschi.jadconfig.RepositoryException;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.junit.Assert.fail;
 
 /**
  * Unit tests for {@link InMemoryRepository}
  *
  * @author jschalanda
- */public class InMemoryRepositoryTest {
-
-    private InMemoryRepository repository;
-
-    @Before
-    public void setUp() {
-
-        repository = new InMemoryRepository();
-    }
-
-    @Test
-    public void testOpen() throws RepositoryException {
-
-        repository.open();
-
-        Assert.assertEquals(0, repository.size());
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void testCloseWithoutOpen() throws RepositoryException {
-
-        repository.close();
-    }
-
-    @Test
-    public void testClose() throws RepositoryException {
-
-        repository.open();
-        Assert.assertEquals(0, repository.size());
-        repository.close();
-
-        try {
-            repository.size();
-            fail("repository.size() should throw an IllegalStateException");
-        } catch (IllegalStateException ex) {
-            // OK
-        }
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void testReadWithoutOpen() {
-
-        repository.read("Test");
-    }
+ */
+public class InMemoryRepositoryTest {
 
     @Test
     public void testRead() throws RepositoryException {
-
         final InMemoryRepository emptyRepository = new InMemoryRepository();
-        emptyRepository.open();
         Assert.assertNull(emptyRepository.read("Test"));
 
         final InMemoryRepository inMemoryRepository = new InMemoryRepository(Collections.singletonMap("Test", "Value"));
-        inMemoryRepository.open();
         Assert.assertEquals("Value", inMemoryRepository.read("Test"));
-    }
-
-
-    @Test(expected = IllegalStateException.class)
-    public void testSizeWithoutOpen() {
-
-        repository.size();
-    }
-
-    @Test
-    public void testSize() throws RepositoryException {
-
-        final InMemoryRepository emptyRepository = new InMemoryRepository();
-        emptyRepository.open();
-        Assert.assertEquals(0, emptyRepository.size());
-
-        final InMemoryRepository inMemoryRepository = new InMemoryRepository(Collections.singletonMap("Test", "Value"));
-        inMemoryRepository.open();
-        Assert.assertEquals(1, inMemoryRepository.size());
     }
 
     @Test
@@ -99,10 +34,25 @@ import static org.junit.Assert.fail;
         map.put("two", "two");
         map.put("three", "three");
 
-        InMemoryRepository inMemoryRepository = new InMemoryRepository(map);
+        Repository inMemoryRepository = new InMemoryRepository(map);
 
         Assert.assertEquals("one", inMemoryRepository.read("one"));
         Assert.assertEquals("two", inMemoryRepository.read("two"));
         Assert.assertEquals("three", inMemoryRepository.read("three"));
+    }
+
+    @Test
+    public void testReadNames() {
+        Map<String, String> map = new HashMap<String, String>();
+        map.put("opensearch.node.roles", "search");
+        map.put("opensearch.node.name", "my-node");
+
+        Repository inMemoryRepository = new InMemoryRepository(map);
+
+        final Collection<String> names = inMemoryRepository.readNames("opensearch.");
+
+        Assert.assertEquals(2, names.size());
+        Assert.assertTrue(names.contains("opensearch.node.name"));
+        Assert.assertTrue(names.contains("opensearch.node.roles"));
     }
 }

--- a/src/test/java/com/github/joschi/jadconfig/repositories/PropertiesRepositoryTest.java
+++ b/src/test/java/com/github/joschi/jadconfig/repositories/PropertiesRepositoryTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collection;
 
 import static org.junit.Assert.fail;
 
@@ -96,5 +97,24 @@ public class PropertiesRepositoryTest {
 
         repository.open();
         repository.close();
+    }
+
+    @Test
+    public void testReadNames() throws RepositoryException {
+        final PropertiesRepository testRepository = new PropertiesRepository(PROPERTIES_FILE);
+        try {
+            testRepository.open();
+            final Collection<String> names = testRepository.readNames("opensearch.");
+            Assert.assertEquals(3, names.size());
+            Assert.assertTrue(names.contains("opensearch.node.roles"));
+            Assert.assertTrue(names.contains("opensearch.node.search.cache.size"));
+            Assert.assertTrue(names.contains("opensearch.path.repo"));
+
+            final Collection<String> underscoreNames = testRepository.readNames("opensearch_");
+            Assert.assertEquals(1, underscoreNames.size());
+            Assert.assertTrue(underscoreNames.contains("opensearch_logger.reindex.level"));
+        } finally {
+            testRepository.close();
+        }
     }
 }

--- a/src/test/java/com/github/joschi/jadconfig/repositories/SystemPropertiesRepositoryTest.java
+++ b/src/test/java/com/github/joschi/jadconfig/repositories/SystemPropertiesRepositoryTest.java
@@ -34,15 +34,18 @@ public class SystemPropertiesRepositoryTest {
     @Test
     public void testReadNames() {
         final TestSystem testSystem = new TestSystem();
-        testSystem.putProperty("opensearch.node.name", "my-node");
-        testSystem.putProperty("opensearch.node.roles", "search");
+        testSystem.putProperty("graylog2.opensearch.node.name", "my-node");
+        testSystem.putProperty("graylog2.opensearch.node.roles", "search");
         testSystem.putProperty("java_home", "/usr/share/java");
-        final Repository testRepository = new SystemPropertiesRepository("", testSystem);
+        final Repository testRepository = new SystemPropertiesRepository("graylog2.", testSystem);
 
         final Collection<String> names = testRepository.readNames("opensearch.");
         Assert.assertEquals(2, names.size());
         Assert.assertTrue(names.contains("opensearch.node.name"));
         Assert.assertTrue(names.contains("opensearch.node.roles"));
+
+        Assert.assertEquals("my-node", testRepository.read("opensearch.node.name"));
+        Assert.assertEquals("search", testRepository.read("opensearch.node.roles"));
     }
 
 }

--- a/src/test/java/com/github/joschi/jadconfig/repositories/SystemPropertiesRepositoryTest.java
+++ b/src/test/java/com/github/joschi/jadconfig/repositories/SystemPropertiesRepositoryTest.java
@@ -1,9 +1,10 @@
 package com.github.joschi.jadconfig.repositories;
 
-import com.github.joschi.jadconfig.RepositoryException;
+import com.github.joschi.jadconfig.Repository;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Collection;
 
 /**
  * Unit tests for {@link SystemPropertiesRepository}
@@ -12,43 +13,36 @@ import org.junit.Test;
  */
 public class SystemPropertiesRepositoryTest {
 
-    private SystemPropertiesRepository repository;
-
-    @Before
-    public void setUp() {
-
-        repository = new SystemPropertiesRepository();
-    }
-
     @Test
-    public void testOpen() throws RepositoryException {
-
-        repository.open();
-    }
-
-    @Test
-    public void testClose() throws RepositoryException {
-
-        repository.close();
-    }
-
-    @Test
-    public void testRead() throws RepositoryException {
+    public void testRead() {
+        final TestSystem testSystem = new TestSystem();
+        testSystem.putProperty("java.version", "1.8");
+        final Repository repository = new SystemPropertiesRepository("", testSystem);
 
         Assert.assertNull(repository.read("This system property should not exist"));
-        Assert.assertEquals(System.getProperty("java.version"), repository.read("java.version"));
+        Assert.assertEquals("1.8", repository.read("java.version"));
     }
 
     @Test
-    public void testReadWithPrefix() throws RepositoryException {
-        final SystemPropertiesRepository testRepository = new SystemPropertiesRepository("java.");
-
-        Assert.assertEquals(System.getProperty("java.version"), testRepository.read("version"));
+    public void testReadWithPrefix() {
+        final TestSystem testSystem = new TestSystem();
+        testSystem.putProperty("java.version", "1.8");
+        final Repository testRepository = new SystemPropertiesRepository("java.", testSystem);
+        Assert.assertEquals("1.8", testRepository.read("version"));
     }
 
     @Test
-    public void testSize() throws RepositoryException {
+    public void testReadNames() {
+        final TestSystem testSystem = new TestSystem();
+        testSystem.putProperty("opensearch.node.name", "my-node");
+        testSystem.putProperty("opensearch.node.roles", "search");
+        testSystem.putProperty("java_home", "/usr/share/java");
+        final Repository testRepository = new SystemPropertiesRepository("", testSystem);
 
-        Assert.assertEquals(System.getProperties().size(), repository.size());
+        final Collection<String> names = testRepository.readNames("opensearch.");
+        Assert.assertEquals(2, names.size());
+        Assert.assertTrue(names.contains("opensearch.node.name"));
+        Assert.assertTrue(names.contains("opensearch.node.roles"));
     }
+
 }

--- a/src/test/java/com/github/joschi/jadconfig/repositories/TestSystem.java
+++ b/src/test/java/com/github/joschi/jadconfig/repositories/TestSystem.java
@@ -1,0 +1,45 @@
+package com.github.joschi.jadconfig.repositories;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * This implementation of {@link JavaSystem} allows defining exact system {@code env} and {@code properties} for unit
+ * test purposes.
+ */
+public class TestSystem implements JavaSystem {
+
+    private final Map<String, String> env = new LinkedHashMap<>();
+    private final Properties properties = new Properties();
+
+    public TestSystem putEnv(String key, String value) {
+        env.put(key, value);
+        return this;
+    }
+
+    @Override
+    public Map<String, String> getenv() {
+        return env;
+    }
+
+    @Override
+    public String getenv(String name) {
+        return env.get(name);
+    }
+
+    @Override
+    public Properties getProperties() {
+        return properties;
+    }
+
+    @Override
+    public String getProperty(String key) {
+        return properties.getProperty(key);
+    }
+
+    public TestSystem putProperty(String key, String value) {
+        properties.put(key, value);
+        return this;
+    }
+}

--- a/src/test/java/com/github/joschi/jadconfig/testbeans/SimpleConfigurationBean.java
+++ b/src/test/java/com/github/joschi/jadconfig/testbeans/SimpleConfigurationBean.java
@@ -60,7 +60,7 @@ public class SimpleConfigurationBean {
     @Parameter(value = "test.Nonexistent3", fallbackPropertyName = "test.fallback.secondary")
     private String myHardcodedDefaultString = "foobar";
 
-    @AggregatedParameter(prefix = "opensearch.")
+    @AggregatedParameter(prefix = {"opensearch.", "opensearch_"}, stripPrefix = true)
     private Map<String, String> opensearchProperties;
 
     public String getMyString() {

--- a/src/test/java/com/github/joschi/jadconfig/testbeans/SimpleConfigurationBean.java
+++ b/src/test/java/com/github/joschi/jadconfig/testbeans/SimpleConfigurationBean.java
@@ -1,12 +1,14 @@
 package com.github.joschi.jadconfig.testbeans;
 
 import com.github.joschi.jadconfig.Parameter;
+import com.github.joschi.jadconfig.AggregatedParameter;
 import com.github.joschi.jadconfig.converters.StringListConverter;
 
 import java.io.File;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 
 public class SimpleConfigurationBean {
 
@@ -57,6 +59,9 @@ public class SimpleConfigurationBean {
 
     @Parameter(value = "test.Nonexistent3", fallbackPropertyName = "test.fallback.secondary")
     private String myHardcodedDefaultString = "foobar";
+
+    @AggregatedParameter(prefix = "opensearch.")
+    private Map<String, String> opensearchProperties;
 
     public String getMyString() {
         return myString;
@@ -120,5 +125,9 @@ public class SimpleConfigurationBean {
 
     public String getMyHardcodedDefaultString() {
         return myHardcodedDefaultString;
+    }
+
+    public Map<String, String> getOpensearchProperties() {
+        return opensearchProperties;
     }
 }

--- a/src/test/resources/testConfiguration.properties
+++ b/src/test/resources/testConfiguration.properties
@@ -16,3 +16,6 @@ test.file=testConfiguration.properties
 test.path=testConfiguration.properties
 test.fallback.primary=prim
 test.fallback.secondary=sec
+opensearch.node.roles=search,cluster_manager
+opensearch.node.search.cache.size=10gb
+opensearch.path.repo=/tmp

--- a/src/test/resources/testConfiguration.properties
+++ b/src/test/resources/testConfiguration.properties
@@ -19,3 +19,4 @@ test.fallback.secondary=sec
 opensearch.node.roles=search,cluster_manager
 opensearch.node.search.cache.size=10gb
 opensearch.path.repo=/tmp
+opensearch_logger.reindex.level=debug


### PR DESCRIPTION
:warning: Keeping for reference now, but I would not recommend merging it and rather use a different approach. This is too fragile, unpredictable and too much relying on conventions.

This PR implements following syntax for aggregated configuration properties:

```
@AggregatedParameter(prefix = "opensearch.", stripPrefix = true)
private Map<String, String> opensearchProperties;
```

Given following config properties file:
```
opensearch.node.roles=search,cluster_manager
opensearch.node.search.cache.size=10gb
opensearch.path.repo=/tmp
```

The map will be contain all three properties, with the prefix removed. 

This is needed to support pass-through properties in the data node. All `opensearch.` prefixed properties will be forwarded to the opensearch process, without the need to explicitly support them in the data node. 
  

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

