### PR TITLE
Feature/parameter types validator/processor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,12 @@
             <version>3.0.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.toolisticon.cute</groupId>
+            <artifactId>cute</artifactId>
+            <version>1.9.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.14.1</version>
+                    <configuration>
+                        <!-- this is needed to skip our annotation processor before it's compiled here, because it's not
+                        compiled yet and would break the build-->
+                        <proc>none</proc>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/github/joschi/jadconfig/ParameterTypesValidator.java
+++ b/src/main/java/com/github/joschi/jadconfig/ParameterTypesValidator.java
@@ -1,0 +1,149 @@
+package com.github.joschi.jadconfig;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.PrimitiveType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Types;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+@javax.annotation.processing.SupportedAnnotationTypes("com.github.joschi.jadconfig.Parameter")
+@javax.annotation.processing.SupportedSourceVersion(SourceVersion.RELEASE_8)
+public class ParameterTypesValidator extends AbstractProcessor {
+
+    @Override
+    public synchronized void init(ProcessingEnvironment processingEnv) {
+        super.init(processingEnv);
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        Types typeUtils = processingEnv.getTypeUtils();
+
+        for (TypeElement annotation : annotations) {
+            // Find elements annotated with MyCustomAnnotation
+            for (Element element : roundEnv.getElementsAnnotatedWith(annotation)) {
+                if (element.getKind().isField()) {
+                    VariableElement field = (VariableElement) element;
+
+                    final String fieldName = getFieldName(field);
+                    TypeMirror fieldType = getBoxedType(typeUtils, field.asType());
+
+                    final AnnotationMirror annotationMirror = element.getAnnotationMirrors()
+                            .stream()
+                            .filter(mirror -> mirror.getAnnotationType().toString().equals(
+                                    Parameter.class.getCanonicalName())).findFirst()
+                            .orElseThrow(() -> new IllegalStateException("This should not happen"));
+
+                    final String parameterName = annotationMirror.getElementValues().entrySet().stream()
+                            .filter(entry -> entry.getKey().getSimpleName().toString().equals("value"))
+                            .map(entry -> (String) entry.getValue().getValue())
+                            .findFirst()
+                            .orElseThrow(() -> new IllegalStateException("Value is mandatory!"));
+
+                    verifyConverterType(annotationMirror, typeUtils, fieldType, parameterName, fieldName);
+                    verifyValidators(annotationMirror, typeUtils, fieldType, parameterName, fieldName);
+                }
+            }
+        }
+        return false;
+    }
+
+    private static String getFieldName(VariableElement field) {
+        final String className = getParentClassName(field);
+        return className + "#" + field.getSimpleName().toString();
+    }
+
+    private static String getParentClassName(VariableElement field) {
+        final Element enclosingElement = field.getEnclosingElement();
+        if (enclosingElement.getKind() == ElementKind.CLASS) {
+            final TypeElement classElement = (TypeElement) enclosingElement;
+            return classElement.getQualifiedName().toString();
+        } else {
+            return enclosingElement.getSimpleName().toString();
+        }
+    }
+
+    private void verifyConverterType(AnnotationMirror annotationMirror, Types types, TypeMirror fieldType, String parameterName, String fieldName) {
+        final Optional<TypeMirror> converter = annotationMirror.getElementValues().entrySet().stream()
+                .filter(entry -> entry.getKey().getSimpleName().toString().equals("converter"))
+                .map(entry -> (TypeMirror) entry.getValue().getValue())
+                .findFirst();
+
+        converter.ifPresent(converterValue -> {
+            TypeElement converterType = (TypeElement) types.asElement(converterValue);
+
+            List<? extends Element> members =
+                    processingEnv.getElementUtils().getAllMembers(converterType);
+
+            ExecutableElement convertFromMethod = members.stream()
+                    .filter(e -> e.getKind() == ElementKind.METHOD)
+                    .map(e -> (ExecutableElement) e)
+                    .filter(m -> m.getSimpleName().contentEquals("convertFrom"))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("This should not happen"));
+
+            final TypeMirror converterReturnType = convertFromMethod.getReturnType();
+            if (!types.isSameType(converterReturnType, fieldType)) {
+                processingEnv.getMessager().printError("Property " + parameterName + " assigned to field " + fieldName + " has type " + fieldType + " but converter expects " + converterReturnType);
+            }
+        });
+    }
+
+    private void verifyValidators(AnnotationMirror annotationMirror, Types types, TypeMirror fieldType, String parameterName, String fieldName) {
+        annotationMirror.getElementValues().entrySet().stream()
+                .filter(entry -> entry.getKey().getSimpleName().toString().equals("validators"))
+                .flatMap(entry -> {
+                    List<? extends AnnotationValue> values =
+                            (List<? extends AnnotationValue>) entry.getValue().getValue();
+                    return values.stream()
+                            .map(v -> (TypeMirror) v.getValue());
+                })
+                .map(type -> (TypeElement) types.asElement(type))
+                .forEach(validatorType -> {
+                    List<? extends Element> members =
+                            processingEnv.getElementUtils().getAllMembers(validatorType);
+
+                    ExecutableElement validatorMethod = members.stream()
+                            .filter(e -> e.getKind() == ElementKind.METHOD)
+                            .map(e -> (ExecutableElement) e)
+                            .filter(m -> m.getSimpleName().contentEquals("validate"))
+                            .findFirst()
+                            .orElseThrow(() -> new IllegalStateException("This should not happen"));
+
+                    final TypeMirror acceptedValidatorType = getValidatorType(types, validatorMethod);
+
+                    if (!types.isSameType(acceptedValidatorType, fieldType)) {
+                        processingEnv.getMessager().printError("Property " + parameterName + " assigned to field " + fieldName + " has type " + fieldType + " but validator expects " + acceptedValidatorType);
+                    }
+                });
+
+    }
+
+    private static TypeMirror getValidatorType(Types types, ExecutableElement convertFromMethod) {
+        final List<? extends VariableElement> converterReturnType = convertFromMethod.getParameters();
+        final TypeMirror acceptedValidatorType = converterReturnType.get(1).asType();
+        return getBoxedType(types, acceptedValidatorType);
+
+    }
+
+    private static TypeMirror getBoxedType(Types types, TypeMirror type) {
+        if (type.getKind().isPrimitive()) {
+            TypeElement boxed = types.boxedClass((PrimitiveType) type);
+            return boxed.asType();
+        } else {
+            return type;
+        }
+    }
+}

--- a/src/main/java/com/github/joschi/jadconfig/ParameterTypesValidator.java
+++ b/src/main/java/com/github/joschi/jadconfig/ParameterTypesValidator.java
@@ -18,9 +18,17 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-@javax.annotation.processing.SupportedAnnotationTypes("com.github.joschi.jadconfig.Parameter")
-@javax.annotation.processing.SupportedSourceVersion(SourceVersion.RELEASE_8)
 public class ParameterTypesValidator extends AbstractProcessor {
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+        return Set.of(Parameter.class.getCanonicalName());
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.RELEASE_8;
+    }
 
     @Override
     public synchronized void init(ProcessingEnvironment processingEnv) {

--- a/src/main/java/com/github/joschi/jadconfig/ParameterTypesValidator.java
+++ b/src/main/java/com/github/joschi/jadconfig/ParameterTypesValidator.java
@@ -31,33 +31,38 @@ public class ParameterTypesValidator extends AbstractProcessor {
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
         Types typeUtils = processingEnv.getTypeUtils();
 
-        for (TypeElement annotation : annotations) {
-            // Find elements annotated with MyCustomAnnotation
-            for (Element element : roundEnv.getElementsAnnotatedWith(annotation)) {
-                if (element.getKind().isField()) {
-                    VariableElement field = (VariableElement) element;
+        annotations.stream()
+                .flatMap(annotation -> roundEnv.getElementsAnnotatedWith(annotation).stream())
+                .map(element -> (VariableElement) element)
+                .forEach(element -> {processField(element,typeUtils);});
+        return false; // do not claim this annotation, let other processors handle it as well
+    }
 
-                    final String fieldName = getFieldName(field);
-                    TypeMirror fieldType = getBoxedType(typeUtils, field.asType());
+    private void processField(VariableElement field, Types typeUtils) {
+        final String fieldName = getFieldName(field);
+        TypeMirror fieldType = getBoxedType(typeUtils, field.asType());
 
-                    final AnnotationMirror annotationMirror = element.getAnnotationMirrors()
-                            .stream()
-                            .filter(mirror -> mirror.getAnnotationType().toString().equals(
-                                    Parameter.class.getCanonicalName())).findFirst()
-                            .orElseThrow(() -> new IllegalStateException("This should not happen"));
+        final AnnotationMirror annotationMirror = getParameterAnnotation(field);
+        final String parameterName = getParameterValue(annotationMirror);
 
-                    final String parameterName = annotationMirror.getElementValues().entrySet().stream()
-                            .filter(entry -> entry.getKey().getSimpleName().toString().equals("value"))
-                            .map(entry -> (String) entry.getValue().getValue())
-                            .findFirst()
-                            .orElseThrow(() -> new IllegalStateException("Value is mandatory!"));
+        verifyConverterType(annotationMirror, typeUtils, fieldType, parameterName, fieldName);
+        verifyValidators(annotationMirror, typeUtils, fieldType, parameterName, fieldName);
+    }
 
-                    verifyConverterType(annotationMirror, typeUtils, fieldType, parameterName, fieldName);
-                    verifyValidators(annotationMirror, typeUtils, fieldType, parameterName, fieldName);
-                }
-            }
-        }
-        return false;
+    private static String getParameterValue(AnnotationMirror annotationMirror) {
+        return annotationMirror.getElementValues().entrySet().stream()
+                .filter(entry -> entry.getKey().getSimpleName().toString().equals("value"))
+                .map(entry -> (String) entry.getValue().getValue())
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Value is mandatory!"));
+    }
+
+    private static AnnotationMirror getParameterAnnotation(Element element) {
+        return element.getAnnotationMirrors()
+                .stream()
+                .filter(mirror -> mirror.getAnnotationType().toString().equals(
+                        Parameter.class.getCanonicalName())).findFirst()
+                .orElseThrow(() -> new IllegalStateException("This should not happen, the element should be always annotated with Parameter annotation"));
     }
 
     private static String getFieldName(VariableElement field) {
@@ -76,23 +81,10 @@ public class ParameterTypesValidator extends AbstractProcessor {
     }
 
     private void verifyConverterType(AnnotationMirror annotationMirror, Types types, TypeMirror fieldType, String parameterName, String fieldName) {
-        final Optional<TypeMirror> converter = annotationMirror.getElementValues().entrySet().stream()
-                .filter(entry -> entry.getKey().getSimpleName().toString().equals("converter"))
-                .map(entry -> (TypeMirror) entry.getValue().getValue())
-                .findFirst();
-
-        converter.ifPresent(converterValue -> {
+        getConverter(annotationMirror).ifPresent(converterValue -> {
             TypeElement converterType = (TypeElement) types.asElement(converterValue);
-
-            List<? extends Element> members =
-                    processingEnv.getElementUtils().getAllMembers(converterType);
-
-            ExecutableElement convertFromMethod = members.stream()
-                    .filter(e -> e.getKind() == ElementKind.METHOD)
-                    .map(e -> (ExecutableElement) e)
-                    .filter(m -> m.getSimpleName().contentEquals("convertFrom"))
-                    .findFirst()
-                    .orElseThrow(() -> new IllegalStateException("This should not happen"));
+            List<? extends Element> members = processingEnv.getElementUtils().getAllMembers(converterType);
+            ExecutableElement convertFromMethod = getConvertFromMethod(members);
 
             final TypeMirror converterReturnType = convertFromMethod.getReturnType();
             if (!types.isSameType(converterReturnType, fieldType)) {
@@ -101,41 +93,58 @@ public class ParameterTypesValidator extends AbstractProcessor {
         });
     }
 
+    private static ExecutableElement getConvertFromMethod(List<? extends Element> members) {
+        return members.stream()
+                .filter(e -> e.getKind() == ElementKind.METHOD)
+                .map(e -> (ExecutableElement) e)
+                .filter(m -> m.getSimpleName().contentEquals("convertFrom"))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("This should not happen, converter should contain a convertFrom method"));
+    }
+
+    private static Optional<TypeMirror> getConverter(AnnotationMirror annotationMirror) {
+        return annotationMirror.getElementValues().entrySet().stream()
+                .filter(entry -> entry.getKey().getSimpleName().toString().equals("converter"))
+                .map(entry -> (TypeMirror) entry.getValue().getValue())
+                .findFirst();
+    }
+
     private void verifyValidators(AnnotationMirror annotationMirror, Types types, TypeMirror fieldType, String parameterName, String fieldName) {
         annotationMirror.getElementValues().entrySet().stream()
                 .filter(entry -> entry.getKey().getSimpleName().toString().equals("validators"))
                 .flatMap(entry -> {
-                    List<? extends AnnotationValue> values =
-                            (List<? extends AnnotationValue>) entry.getValue().getValue();
-                    return values.stream()
-                            .map(v -> (TypeMirror) v.getValue());
+                    List<? extends AnnotationValue> values = (List<? extends AnnotationValue>) entry.getValue().getValue();
+                    return values.stream() .map(v -> (TypeMirror) v.getValue());
                 })
                 .map(type -> (TypeElement) types.asElement(type))
-                .forEach(validatorType -> {
-                    List<? extends Element> members =
-                            processingEnv.getElementUtils().getAllMembers(validatorType);
+                .forEach(validatorType -> verifyValidator(types, fieldType, parameterName, fieldName, validatorType));
+    }
 
-                    ExecutableElement validatorMethod = members.stream()
-                            .filter(e -> e.getKind() == ElementKind.METHOD)
-                            .map(e -> (ExecutableElement) e)
-                            .filter(m -> m.getSimpleName().contentEquals("validate"))
-                            .findFirst()
-                            .orElseThrow(() -> new IllegalStateException("This should not happen"));
+    private void verifyValidator(Types types, TypeMirror fieldType, String parameterName, String fieldName, TypeElement validatorType) {
+        final ExecutableElement validatorMethod = getValidateMethod(validatorType);
+        final TypeMirror acceptedValidatorType = getValidatorType(types, validatorMethod);
 
-                    final TypeMirror acceptedValidatorType = getValidatorType(types, validatorMethod);
+        if (!types.isSameType(acceptedValidatorType, fieldType)) {
+            processingEnv.getMessager().printError("Property " + parameterName + " assigned to field " + fieldName + " has type " + fieldType + " but validator expects " + acceptedValidatorType);
+        }
+    }
 
-                    if (!types.isSameType(acceptedValidatorType, fieldType)) {
-                        processingEnv.getMessager().printError("Property " + parameterName + " assigned to field " + fieldName + " has type " + fieldType + " but validator expects " + acceptedValidatorType);
-                    }
-                });
+    private ExecutableElement getValidateMethod(TypeElement validatorType) {
+        List<? extends Element> members =
+                processingEnv.getElementUtils().getAllMembers(validatorType);
 
+        return members.stream()
+                .filter(e -> e.getKind() == ElementKind.METHOD)
+                .map(e -> (ExecutableElement) e)
+                .filter(m -> m.getSimpleName().contentEquals("validate"))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("This should not happen"));
     }
 
     private static TypeMirror getValidatorType(Types types, ExecutableElement convertFromMethod) {
         final List<? extends VariableElement> converterReturnType = convertFromMethod.getParameters();
         final TypeMirror acceptedValidatorType = converterReturnType.get(1).asType();
         return getBoxedType(types, acceptedValidatorType);
-
     }
 
     private static TypeMirror getBoxedType(Types types, TypeMirror type) {

--- a/src/main/java/com/github/joschi/jadconfig/ParameterTypesValidator.java
+++ b/src/main/java/com/github/joschi/jadconfig/ParameterTypesValidator.java
@@ -34,7 +34,9 @@ public class ParameterTypesValidator extends AbstractProcessor {
         annotations.stream()
                 .flatMap(annotation -> roundEnv.getElementsAnnotatedWith(annotation).stream())
                 .map(element -> (VariableElement) element)
-                .forEach(element -> {processField(element,typeUtils);});
+                .forEach(element -> {
+                    processField(element, typeUtils);
+                });
         return false; // do not claim this annotation, let other processors handle it as well
     }
 
@@ -45,8 +47,8 @@ public class ParameterTypesValidator extends AbstractProcessor {
         final AnnotationMirror annotationMirror = getParameterAnnotation(field);
         final String parameterName = getParameterValue(annotationMirror);
 
-        verifyConverterType(annotationMirror, typeUtils, fieldType, parameterName, fieldName);
-        verifyValidators(annotationMirror, typeUtils, fieldType, parameterName, fieldName);
+        verifyConverterType(annotationMirror, typeUtils, field, fieldType, parameterName, fieldName);
+        verifyValidators(annotationMirror, typeUtils, field, fieldType, parameterName, fieldName);
     }
 
     private static String getParameterValue(AnnotationMirror annotationMirror) {
@@ -80,7 +82,7 @@ public class ParameterTypesValidator extends AbstractProcessor {
         }
     }
 
-    private void verifyConverterType(AnnotationMirror annotationMirror, Types types, TypeMirror fieldType, String parameterName, String fieldName) {
+    private void verifyConverterType(AnnotationMirror annotationMirror, Types types, VariableElement field, TypeMirror fieldType, String parameterName, String fieldName) {
         getConverter(annotationMirror).ifPresent(converterValue -> {
             TypeElement converterType = (TypeElement) types.asElement(converterValue);
             List<? extends Element> members = processingEnv.getElementUtils().getAllMembers(converterType);
@@ -88,7 +90,7 @@ public class ParameterTypesValidator extends AbstractProcessor {
 
             final TypeMirror converterReturnType = convertFromMethod.getReturnType();
             if (!types.isSameType(converterReturnType, fieldType)) {
-                processingEnv.getMessager().printError("Property " + parameterName + " assigned to field " + fieldName + " has type " + fieldType + " but converter expects " + converterReturnType);
+                processingEnv.getMessager().printError("Property " + parameterName + " assigned to field " + fieldName + " has type " + fieldType + " but converter expects " + converterReturnType, field);
             }
         });
     }
@@ -109,23 +111,23 @@ public class ParameterTypesValidator extends AbstractProcessor {
                 .findFirst();
     }
 
-    private void verifyValidators(AnnotationMirror annotationMirror, Types types, TypeMirror fieldType, String parameterName, String fieldName) {
+    private void verifyValidators(AnnotationMirror annotationMirror, Types types, VariableElement field, TypeMirror fieldType, String parameterName, String fieldName) {
         annotationMirror.getElementValues().entrySet().stream()
                 .filter(entry -> entry.getKey().getSimpleName().toString().equals("validators"))
                 .flatMap(entry -> {
                     List<? extends AnnotationValue> values = (List<? extends AnnotationValue>) entry.getValue().getValue();
-                    return values.stream() .map(v -> (TypeMirror) v.getValue());
+                    return values.stream().map(v -> (TypeMirror) v.getValue());
                 })
                 .map(type -> (TypeElement) types.asElement(type))
-                .forEach(validatorType -> verifyValidator(types, fieldType, parameterName, fieldName, validatorType));
+                .forEach(validatorType -> verifyValidator(types, field, fieldType, parameterName, fieldName, validatorType));
     }
 
-    private void verifyValidator(Types types, TypeMirror fieldType, String parameterName, String fieldName, TypeElement validatorType) {
+    private void verifyValidator(Types types, VariableElement field, TypeMirror fieldType, String parameterName, String fieldName, TypeElement validatorType) {
         final ExecutableElement validatorMethod = getValidateMethod(validatorType);
         final TypeMirror acceptedValidatorType = getValidatorType(types, validatorMethod);
 
         if (!types.isSameType(acceptedValidatorType, fieldType)) {
-            processingEnv.getMessager().printError("Property " + parameterName + " assigned to field " + fieldName + " has type " + fieldType + " but validator expects " + acceptedValidatorType);
+            processingEnv.getMessager().printError("Property " + parameterName + " assigned to field " + fieldName + " has type " + fieldType + " but validator expects " + acceptedValidatorType, field);
         }
     }
 

--- a/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+com.github.joschi.jadconfig.ParameterTypesValidator

--- a/src/test/java/com/github/joschi/jadconfig/ParameterTypesValidatorTest.java
+++ b/src/test/java/com/github/joschi/jadconfig/ParameterTypesValidatorTest.java
@@ -25,10 +25,10 @@ class ParameterTypesValidatorTest {
                 .compilationFails()
                 .andThat()
                 .compilerMessage()
-                .ofKindError().equals("Property my_int assigned to field MyAnnotationValidatorTestClass#myIntField has type java.lang.Integer but converter expects java.lang.Long")
+                .ofKindError().atLine(9).atColumn(17).equals("Property my_int assigned to field MyAnnotationValidatorTestClass#myIntField has type java.lang.Integer but converter expects java.lang.Long")
                 .andThat()
                 .compilerMessage()
-                .ofKindError().equals("Property my_duration assigned to field MyAnnotationValidatorTestClass#myDurationField has type java.time.Duration but validator expects com.github.joschi.jadconfig.util.Duration")
+                .ofKindError().atLine(12).atColumn(22).equals("Property my_duration assigned to field MyAnnotationValidatorTestClass#myDurationField has type java.time.Duration but validator expects com.github.joschi.jadconfig.util.Duration")
                 .executeTest();
     }
 }

--- a/src/test/java/com/github/joschi/jadconfig/ParameterTypesValidatorTest.java
+++ b/src/test/java/com/github/joschi/jadconfig/ParameterTypesValidatorTest.java
@@ -1,0 +1,34 @@
+package com.github.joschi.jadconfig;
+
+import io.toolisticon.cute.Cute;
+import io.toolisticon.cute.CuteApi;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ParameterTypesValidatorTest {
+
+    CuteApi.BlackBoxTestSourceFilesInterface compileTestBuilder;
+
+    @BeforeEach
+    public void init() {
+        compileTestBuilder = Cute
+                .blackBoxTest()
+                .given()
+                .processor(ParameterTypesValidator.class);
+    }
+
+    @Test
+    public void testPropertyValidatorProcessor() {
+        compileTestBuilder
+                .andSourceFiles("/com/github/joschi/jadconfig/MyAnnotationValidatorTestClass.java")
+                .whenCompiled().thenExpectThat()
+                .compilationFails()
+                .andThat()
+                .compilerMessage()
+                .ofKindError().equals("Property my_int assigned to field MyAnnotationValidatorTestClass#myIntField has type java.lang.Integer but converter expects java.lang.Long")
+                .andThat()
+                .compilerMessage()
+                .ofKindError().equals("Property my_duration assigned to field MyAnnotationValidatorTestClass#myDurationField has type java.time.Duration but validator expects com.github.joschi.jadconfig.util.Duration")
+                .executeTest();
+    }
+}

--- a/src/test/resources/com/github/joschi/jadconfig/MyAnnotationValidatorTestClass.java
+++ b/src/test/resources/com/github/joschi/jadconfig/MyAnnotationValidatorTestClass.java
@@ -1,0 +1,13 @@
+import com.github.joschi.jadconfig.converters.LongConverter;
+import com.github.joschi.jadconfig.Parameter;
+import com.github.joschi.jadconfig.validators.PositiveDurationValidator;
+
+import java.time.Duration;
+
+public class MyAnnotationValidatorTestClass {
+    @Parameter(value = "my_int", converter = LongConverter.class)
+    private int myIntField = 10;
+
+    @Parameter(value = "my_duration", validators = {PositiveDurationValidator.class})
+    private Duration myDurationField = Duration.ofDays(1);
+}


### PR DESCRIPTION


So far there is nothing checking types consistency/compatibility between configuration properties, their converters and validators. This newly added annotation processor is doing exactly that - checking that the property java type is matching the expected converter type and validator types, catching bugs during compile time, long before they could cause any problems. 

This validator has the ability to detect such errors https://github.com/Graylog2/graylog2-server/pull/24455 (even without default value set and validated, which helped to discover the issue initially)

## Usage
Add this to the annotationProcessorPaths in pom.xml

```
<path>
  <groupId>org.graylog</groupId>
  <artifactId>jadconfig</artifactId>
  <version>${jadconfig.version}</version>
</path>
```

                         
<img width="1546" height="832" alt="image" src="https://github.com/user-attachments/assets/4e60293d-4694-453f-9a91-0d6144ef4408" />

<img width="1787" height="454" alt="image" src="https://github.com/user-attachments/assets/9e3b0cb1-0b0e-4f57-9bbb-0fd7ca6a970f" />

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

